### PR TITLE
#64: Added cargo toolchain step to every rust

### DIFF
--- a/.github/workflows/rust_check.yml
+++ b/.github/workflows/rust_check.yml
@@ -16,5 +16,9 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+    - name: Get Toolchain
+      uses: actions-rs/toolchain@v1
+      with:
+        toolchain: stable
     - name: Check
       run: cargo check --workspace --verbose

--- a/.github/workflows/rust_release.yml
+++ b/.github/workflows/rust_release.yml
@@ -17,8 +17,12 @@ jobs:
       - uses: actions/checkout@v2
         with:
           ref: staging
+      - name: Get Toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
       - name: Run lint on project
-        run: RUSTFLAGScargo check
+        run: cargo check
         env:
           RUSTFLAGS: "-D warnings"
       - name: Run lint on VM
@@ -31,6 +35,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master
+      - name: Get Toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
       - name: Merge staging-> main
         uses: devmasx/merge-branch@master
         with:
@@ -47,6 +55,10 @@ jobs:
       - uses: actions/checkout@v2
         with:
           ref: main
+      - name: Get Toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
       - name: Bump version and push tag
         id: tag_version
         uses: mathieudutour/github-tag-action@v5.6

--- a/.github/workflows/rust_test.yml
+++ b/.github/workflows/rust_test.yml
@@ -12,5 +12,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - name: Get Toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
       - name: Test
         run: cargo test --workspace --verbose


### PR DESCRIPTION
Now uses the the toolchain getter to make sure cargo is always the most recent stable version