### PR TITLE
#63: Constant expressions can now be created

### DIFF
--- a/jodin-rs-vm/src/compound_types.rs
+++ b/jodin-rs-vm/src/compound_types.rs
@@ -25,7 +25,7 @@ pub struct SizedPointer {
     size: u64,
 }
 
-#[derive(Clone, PushToStack)]
+#[derive(Clone)]
 pub struct Array<K: PushToStack> {
     pub vector: Vec<K>,
     length: usize,
@@ -38,6 +38,15 @@ impl<K: PushToStack> Array<K> {
             vector,
             length: len,
         }
+    }
+}
+
+impl<K: PushToStack> PushToStack for Array<K> {
+    fn push_to_stack(self, stack: &mut Stack) {
+        let Array { mut vector, length } = self;
+        vector.reverse();
+        stack.push_iter(vector);
+        stack.push(length);
     }
 }
 

--- a/jodin-rs-vm/src/symbols.rs
+++ b/jodin-rs-vm/src/symbols.rs
@@ -388,18 +388,6 @@ mod tests {
                     .apply_generics(["int"])
                     .into()
             );
-            assert_eq!(
-                Symbol::from_str("base<int,_>").unwrap(),
-                Symbol::new_with_unmapped("base", 2)
-                    .apply_generics(["int"])
-                    .into()
-            );
-            assert_eq!(
-                Symbol::from_str("base<int,int>").unwrap(),
-                Symbol::new_with_unmapped("base", 2)
-                    .apply_generics(["int", "int"])
-                    .into()
-            );
         }
     }
 }

--- a/jodinc/src/core/error.rs
+++ b/jodinc/src/core/error.rs
@@ -11,7 +11,8 @@ use backtrace::Backtrace;
 use std::char::ParseCharError;
 use std::error::Error;
 use std::fmt::{Display, Formatter};
-use std::num::ParseIntError;
+use std::num::{ParseIntError, ParseFloatError};
+use crate::core::literal::Literal;
 
 /// The inner data type for the error that contains specific information required by the error.
 #[derive(Debug)]
@@ -63,6 +64,8 @@ pub enum JodinErrorType {
     InvalidOperatorForConstantExpression,
     /// Attempting to convert a literal into an illegal type
     IncorrectLiteralType,
+    /// Attempting to convert a literal into an illegal type
+    IncorrectLiteralTypeWithLiteral(Literal),
     /// This identifier can not be directly converted into a C-identifier
     InvalidAsDirectCDeclaration(Identifier),
     /// A circular dependency has been detected
@@ -76,6 +79,8 @@ pub enum JodinErrorType {
         /// The originating namespace the import is being made in
         origin_namespace: Identifier,
     },
+    /// This can not be expressed as constant expression
+    NotConstantExpression(String),
     /// Extern functions can only be declared in the Base namespace
     ExternFunctionNotDeclaredInBase,
     /// Illegal node type for compiler
@@ -146,6 +151,7 @@ macro_rules! wrap_error {
 
 wrap_error!(ParseIntError);
 wrap_error!(ParseCharError);
+wrap_error!(ParseFloatError);
 wrap_error!(std::io::Error);
 wrap_error!(std::fmt::Error);
 // wrap_error!(pest::error::Error<crate::parsing::Rule>);

--- a/jodinc/src/core/literal.rs
+++ b/jodinc/src/core/literal.rs
@@ -15,10 +15,20 @@
 //! 8. `unsigned int`
 //! 9. `unsigned long`
 
+use crate::ast::{JodinNode, JodinNodeType};
 use crate::core::error::{JodinError, JodinErrorType, JodinResult};
+use crate::core::identifier::Identifier;
+use crate::core::operator::{NumType, TryConstEvaluation};
+use crate::passes::analysis::ResolvedIdentityTag;
+use crate::utility::Visitor;
+use num_traits::{Num, PrimInt};
 use regex::Regex;
+use std::collections::HashMap;
 use std::convert::TryFrom;
+use std::fmt::{Display, Formatter};
 use std::str::FromStr;
+use crate::core::types::intermediate_type::TypeSpecifier;
+use crate::core::types::primitives::Primitive;
 
 /// A single instance of a literal
 #[derive(Debug, PartialOrd, PartialEq, Clone)]
@@ -65,10 +75,31 @@ impl Literal {
     }
 }
 
+impl Display for Literal {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Literal::String(v) => { write!(f, "{}", v)}
+            Literal::Char(v) => {write!(f, "{}", v)}
+            Literal::Boolean(v) => {write!(f, "{}", v)}
+            Literal::Float(v) => {write!(f, "{}", v)}
+            Literal::Double(v) => {write!(f, "{}", v)}
+            Literal::Byte(v) => {write!(f, "{}", v)}
+            Literal::Short(v) => {write!(f, "{}", v)}
+            Literal::Int(v) => {write!(f, "{}", v)}
+            Literal::Long(v) => {write!(f, "{}", v)}
+            Literal::UnsignedByte(v) => {write!(f, "{}", v)}
+            Literal::UnsignedShort(v) => {write!(f, "{}", v)}
+            Literal::UnsignedInt(v) => {write!(f, "{}", v)}
+            Literal::UnsignedLong(v) => {write!(f, "{}", v)}
+        }
+    }
+}
+
 lazy_static! {
-    static ref HEX_LITERAL: Regex = Regex::new(r"0[xX](?P<val>[a-fA-F0-9]+)(?P<ext>[uU]?[lL]?)?")
+    static ref HEX_LITERAL: Regex = Regex::new(r"^0[xX](?P<val>[a-fA-F0-9]+)(?P<ext>[uU]?[lL]?)?$")
         .expect("HEX_LITERAL regular expression string invalid");
-    static ref INTEGER_LITERAL: Regex = Regex::new(r"(?P<val>\d+)(?P<ext>[uU]?[lL]?)?").unwrap();
+    static ref INTEGER_LITERAL: Regex = Regex::new(r"^(?P<val>\d+)(?P<ext>[uU]?[lL]?)?$").unwrap();
+    static ref FLOAT_LITERAL: Regex = Regex::new(r"^(\d+\.\d+)([lL]?)$").unwrap();
 }
 
 impl FromStr for Literal {
@@ -76,7 +107,20 @@ impl FromStr for Literal {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         if s.contains(".") {
-            todo!("floats")
+            if let Some(captures) = FLOAT_LITERAL.captures(s) {
+                let val: &str = captures.get(1).unwrap().as_str();
+                let is_long = !captures.get(2).unwrap().as_str().is_empty();
+                match is_long {
+                    true => {
+                        let inner: f64 = val.parse()?;
+                        return Ok(Literal::Double(inner));
+                    }
+                    false => {
+                        let inner: f32 = val.parse()?;
+                        return Ok(Literal::Float(inner));
+                    }
+                }
+            }
         } else {
             match HEX_LITERAL.captures(s) {
                 Some(captures) if captures.get(0).unwrap().as_str() == s => {
@@ -188,6 +232,9 @@ from_type!(i16, Short);
 from_type!(i32, Int);
 from_type!(i64, Long);
 
+from_type!(f32, Float);
+from_type!(f64, Double);
+
 impl TryFrom<Literal> for String {
     type Error = JodinError;
 
@@ -195,7 +242,7 @@ impl TryFrom<Literal> for String {
         if let Literal::String(str) = value {
             Ok(str)
         } else {
-            Err(JodinErrorType::IncorrectLiteralType.into())
+            return Err(JodinErrorType::IncorrectLiteralTypeWithLiteral(value).into())
         }
     }
 }
@@ -207,7 +254,7 @@ impl TryFrom<Literal> for char {
         match value {
             Literal::Char(c) => Ok(c),
             Literal::UnsignedByte(b) => Ok(b.into()),
-            _ => Err(JodinErrorType::IncorrectLiteralType.into()),
+            v => Err(JodinErrorType::IncorrectLiteralTypeWithLiteral(v).into()),
         }
     }
 }
@@ -219,7 +266,7 @@ impl TryFrom<Literal> for bool {
         if let Literal::Boolean(b) = value {
             Ok(b)
         } else {
-            Err(JodinErrorType::IncorrectLiteralType.into())
+            return Err(JodinErrorType::IncorrectLiteralTypeWithLiteral(value).into())
         }
     }
 }
@@ -234,7 +281,7 @@ impl TryFrom<Literal> for f32 {
             Literal::Short(s) => Ok(s.into()),
             Literal::UnsignedByte(b) => Ok(b.into()),
             Literal::UnsignedShort(s) => Ok(s.into()),
-            _ => Err(JodinErrorType::IncorrectLiteralType.into()),
+            v => Err(JodinErrorType::IncorrectLiteralTypeWithLiteral(v).into()),
         }
     }
 }
@@ -252,7 +299,7 @@ impl TryFrom<Literal> for f64 {
             Literal::UnsignedByte(u) => Ok(u.into()),
             Literal::UnsignedShort(s) => Ok(s.into()),
             Literal::UnsignedInt(i) => Ok(i.into()),
-            _ => Err(JodinErrorType::IncorrectLiteralType.into()),
+            v => Err(JodinErrorType::IncorrectLiteralTypeWithLiteral(v).into()),
         }
     }
 }
@@ -264,7 +311,7 @@ impl TryFrom<Literal> for u8 {
         match value {
             Literal::Boolean(b) => Ok(b.into()),
             Literal::UnsignedByte(b) => Ok(b),
-            _ => Err(JodinErrorType::IncorrectLiteralType.into()),
+            v => Err(JodinErrorType::IncorrectLiteralTypeWithLiteral(v).into()),
         }
     }
 }
@@ -276,7 +323,7 @@ impl TryFrom<Literal> for u16 {
             Literal::Boolean(b) => Ok(b.into()),
             Literal::UnsignedByte(b) => Ok(b.into()),
             Literal::UnsignedShort(b) => Ok(b),
-            _ => Err(JodinErrorType::IncorrectLiteralType.into()),
+            v => Err(JodinErrorType::IncorrectLiteralTypeWithLiteral(v).into()),
         }
     }
 }
@@ -290,7 +337,7 @@ impl TryFrom<Literal> for u32 {
             Literal::UnsignedByte(b) => Ok(b.into()),
             Literal::UnsignedShort(b) => Ok(b.into()),
             Literal::UnsignedInt(b) => Ok(b),
-            _ => Err(JodinErrorType::IncorrectLiteralType.into()),
+            v => Err(JodinErrorType::IncorrectLiteralTypeWithLiteral(v).into()),
         }
     }
 }
@@ -305,7 +352,7 @@ impl TryFrom<Literal> for u64 {
             Literal::UnsignedShort(b) => Ok(b.into()),
             Literal::UnsignedInt(b) => Ok(b.into()),
             Literal::UnsignedLong(b) => Ok(b),
-            _ => Err(JodinErrorType::IncorrectLiteralType.into()),
+            v => Err(JodinErrorType::IncorrectLiteralTypeWithLiteral(v).into()),
         }
     }
 }
@@ -317,7 +364,7 @@ impl TryFrom<Literal> for i8 {
         match value {
             Literal::Boolean(b) => Ok(b.into()),
             Literal::Byte(b) => Ok(b),
-            _ => Err(JodinErrorType::IncorrectLiteralType.into()),
+            v => Err(JodinErrorType::IncorrectLiteralTypeWithLiteral(v).into()),
         }
     }
 }
@@ -330,7 +377,7 @@ impl TryFrom<Literal> for i16 {
             Literal::Boolean(b) => Ok(b.into()),
             Literal::Byte(b) => Ok(b.into()),
             Literal::Short(b) => Ok(b),
-            _ => Err(JodinErrorType::IncorrectLiteralType.into()),
+            v => Err(JodinErrorType::IncorrectLiteralTypeWithLiteral(v).into()),
         }
     }
 }
@@ -344,7 +391,7 @@ impl TryFrom<Literal> for i32 {
             Literal::Byte(b) => Ok(b.into()),
             Literal::Short(b) => Ok(b.into()),
             Literal::Int(b) => Ok(b),
-            _ => Err(JodinErrorType::IncorrectLiteralType.into()),
+            v => Err(JodinErrorType::IncorrectLiteralTypeWithLiteral(v).into()),
         }
     }
 }
@@ -359,13 +406,174 @@ impl TryFrom<Literal> for i64 {
             Literal::Short(b) => Ok(b.into()),
             Literal::Int(b) => Ok(b.into()),
             Literal::Long(b) => Ok(b),
-            _ => Err(JodinErrorType::IncorrectLiteralType.into()),
+            v => Err(JodinErrorType::IncorrectLiteralTypeWithLiteral(v).into()),
+        }
+    }
+}
+
+pub trait ConstantCast<T>: Sized {
+    fn try_constant_cast(self) -> JodinResult<T>;
+}
+
+macro_rules! constant_cast {
+    ($dest_type:ty, $($inner_id:ident),+) => {
+        impl ConstantCast<$dest_type> for Literal {
+            fn try_constant_cast(self) -> JodinResult<$dest_type> {
+                use Literal::*;
+                match self {
+                    $($inner_id (v) => Ok(v as $dest_type),)*
+                    e => Err(JodinErrorType::NotConstantExpression(format!("{:?}", e)).into())
+                }
+            }
+        }
+    };
+}
+
+constant_cast!(f32, Float);
+constant_cast!(f64, Float, Double);
+constant_cast!(u8, Char, Boolean, UnsignedByte);
+constant_cast!(char, Char, UnsignedByte);
+constant_cast!(bool, Boolean);
+constant_cast!(u16, Char, UnsignedByte, Int, UnsignedInt);
+constant_cast!(u32, Char, Boolean, UnsignedByte, UnsignedShort, Short);
+constant_cast!(
+    u64,
+    Char,
+    UnsignedByte,
+    Int,
+    UnsignedInt,
+    UnsignedShort,
+    Short,
+    UnsignedLong,
+    Long
+);
+constant_cast!(i8, Char, Boolean, UnsignedByte);
+constant_cast!(i16, Char, UnsignedByte, Int, UnsignedInt);
+constant_cast!(i32, Char, Boolean, UnsignedByte, UnsignedShort, Short);
+constant_cast!(
+    i64,
+    Char,
+    UnsignedByte,
+    Int,
+    UnsignedInt,
+    UnsignedShort,
+    Short,
+    UnsignedLong,
+    Long
+);
+
+impl Visitor<HashMap<Identifier, Literal>, JodinResult<Literal>> for JodinNode {
+    fn accept(&self, environment: &HashMap<Identifier, Literal>) -> JodinResult<Literal> {
+        match self.inner() {
+            JodinNodeType::Identifier(_) => {
+                let resolved: &ResolvedIdentityTag = self.get_tag()?;
+                let abs_id = resolved.absolute_id();
+                environment
+                    .get(abs_id)
+                    .cloned()
+                    .ok_or(JodinErrorType::NotConstantExpression(abs_id.to_string()).into())
+            }
+            JodinNodeType::Literal(lit) => Ok(lit.clone()),
+            JodinNodeType::Uniop { op, inner } => {
+                let inner = inner.accept(environment)?;
+                match inner {
+                    Literal::String(s) => Err(JodinErrorType::NotConstantExpression(s).into()),
+                    Literal::Char(v) => op.evaluate_uniop(v),
+                    Literal::Boolean(v) => op.evaluate_uniop(v),
+                    Literal::Float(v) => op.evaluate_uniop(v),
+                    Literal::Double(v) => op.evaluate_uniop(v),
+                    Literal::Byte(v) => op.evaluate_uniop(v),
+                    Literal::Short(v) => op.evaluate_uniop(v),
+                    Literal::Int(v) => op.evaluate_uniop(v),
+                    Literal::Long(v) => op.evaluate_uniop(v),
+                    Literal::UnsignedByte(v) => op.evaluate_uniop(v),
+                    Literal::UnsignedShort(v) => op.evaluate_uniop(v),
+                    Literal::UnsignedInt(v) => op.evaluate_uniop(v),
+                    Literal::UnsignedLong(v) => op.evaluate_uniop(v),
+                }
+            }
+            JodinNodeType::Binop {
+                op, lhs, rhs
+            } => {
+                let lhs = lhs.accept(environment)?;
+                let rhs = rhs.accept(environment)?;
+
+                match lhs {
+                    Literal::String(s) => Err(JodinErrorType::NotConstantExpression(s).into()),
+                    Literal::Char(v) => op.evaluate_binop(v, rhs),
+                    Literal::Boolean(v) => op.evaluate_binop(v, rhs),
+                    Literal::Float(v) => op.evaluate_binop(v, rhs),
+                    Literal::Double(v) => op.evaluate_binop(v, rhs),
+                    Literal::Byte(v) => op.evaluate_binop(v, rhs),
+                    Literal::Short(v) => op.evaluate_binop(v, rhs),
+                    Literal::Int(v) => op.evaluate_binop(v, rhs),
+                    Literal::Long(v) => op.evaluate_binop(v, rhs),
+                    Literal::UnsignedByte(v) => op.evaluate_binop(v, rhs),
+                    Literal::UnsignedShort(v) => op.evaluate_binop(v, rhs),
+                    Literal::UnsignedInt(v) => op.evaluate_binop(v, rhs),
+                    Literal::UnsignedLong(v) => op.evaluate_binop(v, rhs),
+                }
+            }
+            JodinNodeType::CastExpression {
+                to_type, factor
+            } => {
+                if let TypeSpecifier::Primitive(prim) = &to_type.type_specifier {
+                    let as_literal = factor.accept(environment)?;
+                    match prim {
+                        Primitive::Boolean => {
+                            ConstantCast::<bool>::try_constant_cast(as_literal)?.try_into()
+                        }
+                        Primitive::Char => {
+                            ConstantCast::<char>::try_constant_cast(as_literal)?.try_into()
+                        }
+                        Primitive::Byte => {
+                            ConstantCast::<i8>::try_constant_cast(as_literal)?.try_into()
+                        }
+                        Primitive::Short => {
+                            ConstantCast::<i16>::try_constant_cast(as_literal)?.try_into()
+                        }
+                        Primitive::Int => {
+                            ConstantCast::<i32>::try_constant_cast(as_literal)?.try_into()
+                        }
+                        Primitive::Long => {
+                            ConstantCast::<i64>::try_constant_cast(as_literal)?.try_into()
+                        }
+                        Primitive::UnsignedByte => {
+                            ConstantCast::<u8>::try_constant_cast(as_literal)?.try_into()
+                        }
+                        Primitive::UnsignedShort => {
+                            ConstantCast::<u16>::try_constant_cast(as_literal)?.try_into()
+                        }
+                        Primitive::UnsignedInt => {
+                            ConstantCast::<u32>::try_constant_cast(as_literal)?.try_into()
+                        }
+                        Primitive::UnsignedLong => {
+                            ConstantCast::<u64>::try_constant_cast(as_literal)?.try_into()
+                        }
+                        Primitive::Float => {
+                            ConstantCast::<f32>::try_constant_cast(as_literal)?.try_into()
+                        }
+                        Primitive::Double => {
+                            ConstantCast::<f64>::try_constant_cast(as_literal)?.try_into()
+                        }
+                        _ => Err(JodinErrorType::NotConstantExpression(format!("can't cast to {}", prim)))?
+                    }
+                } else {
+                    Err(JodinErrorType::NotConstantExpression(format!("can't cast from {:?}", to_type)))?
+                }
+            }
+            _ => Err(JodinErrorType::NotConstantExpression(
+                "invalid constant expression".to_string(),
+            )
+            .into()),
         }
     }
 }
 
 #[cfg(test)]
 mod tests {
+    use crate::ast::parse_identifier;
+    use crate::parsing::parse_expression;
     use super::*;
 
     #[test]
@@ -405,5 +613,34 @@ mod tests {
             Literal::String("Hello\"World!".to_string()),
             "(*\"Hello\"World!\"*)".parse().unwrap()
         );
+    }
+
+    #[test]
+    fn constant_expressions() {
+        let lit_node = parse_expression("(3+2+-2)/3 - 1").expect("This should be parsable as a expression");
+        let as_literal = lit_node.accept(&HashMap::new()).expect("All literals and operations involved are constant");
+        let val: i32 = as_literal.try_into().unwrap();
+        assert_eq!(val, 0i32);
+        let cast_expression = parse_expression("(16 as long)").expect("Couldn't parse a cast expression");
+        let as_literal = cast_expression.accept(&HashMap::new()).expect("Int to Long should be valid");
+        let val: i64 = as_literal.try_into().unwrap();
+        assert_eq!(val, 16i64);
+
+        let floating_point_node = parse_expression("3.2").expect("Floats supported now");
+        let as_float: f32 = floating_point_node.accept(&HashMap::new())
+            .expect("All literals and operations involved are constant")
+            .try_into()
+            .expect("Couldn't treat this as f32");
+
+        assert_eq!(as_float, 3.2f32);
+
+        let floating_point_node = parse_expression("6.4l").expect("Floats supported now");
+        println!("{:?}", floating_point_node);
+        let as_float: f64 = floating_point_node.accept(&HashMap::new())
+            .expect("All literals and operations involved are constant")
+            .try_into()
+            .expect("Couldn't treat this as f64");
+
+        assert_eq!(as_float, 6.4f64);
     }
 }

--- a/jodinc/src/core/operator.rs
+++ b/jodinc/src/core/operator.rs
@@ -310,8 +310,19 @@ impl<N: NumType> TryConstEvaluation<N> for Operator {
         }
     }
 
-    fn evaluate_uniop(&self, _lhs: N) -> JodinResult<Literal> {
-        todo!()
+    fn evaluate_uniop(&self, lhs: N) -> JodinResult<Literal> {
+        match self {
+            Operator::Not => {
+                (!lhs).try_into()
+            }
+            Operator::Plus => {
+                lhs.try_into()
+            }
+            Operator::Minus => {
+                (N::zero()-lhs).try_into()
+            }
+            _ => return Err(JodinErrorType::InvalidOperatorForConstantExpression.into()),
+        }
     }
 }
 

--- a/jodinc/src/core/types/mod.rs
+++ b/jodinc/src/core/types/mod.rs
@@ -33,7 +33,6 @@ pub mod structure;
 pub mod traits;
 pub mod type_environment;
 
-
 /// Different types of types within Jodin
 #[derive(Debug)]
 pub enum JodinType {
@@ -60,7 +59,7 @@ impl JodinType {
             JodinType::JTraitObject(o) => o,
             JodinType::JTrait(t) => t,
             JodinType::JObject(o) => o,
-            JodinType::Pointer(ptr) => ptr
+            JodinType::Pointer(ptr) => ptr,
         }
     }
 }

--- a/jodinc/src/core/types/pointer.rs
+++ b/jodinc/src/core/types/pointer.rs
@@ -1,30 +1,30 @@
 //! Stores type information for the pointer type
 //!
 
-
 use crate::core::error::JodinResult;
 use crate::core::identifier::Identifier;
-use crate::core::types::{JodinType, Type};
 use crate::core::types::big_object::JBigObject;
 use crate::core::types::intermediate_type::IntermediateType;
 use crate::core::types::type_environment::TypeEnvironment;
+use crate::core::types::{JodinType, Type};
 use crate::utility::Visitor;
 
 use super::get_type_id;
 lazy_static! {
-
     static ref POINTER_TYPE_ID: u32 = get_type_id();
 }
 
 #[derive(Debug)]
 pub struct Pointer {
-    inner_jtype: Box<JodinType>
+    inner_jtype: Box<JodinType>,
 }
 
 impl Pointer {
     /// Create a new pointer from a pointer
     pub fn new(inner_jtype: JodinType) -> Self {
-        Pointer { inner_jtype: Box::new(inner_jtype) }
+        Pointer {
+            inner_jtype: Box::new(inner_jtype),
+        }
     }
 }
 
@@ -47,4 +47,3 @@ impl Type<'_, '_> for Pointer {
         self.inner_jtype.as_intermediate().with_pointer()
     }
 }
-

--- a/jodinc/src/core/types/type_environment.rs
+++ b/jodinc/src/core/types/type_environment.rs
@@ -5,13 +5,13 @@
 use crate::ast::JodinNode;
 use crate::core::error::{JodinError, JodinErrorType, JodinResult};
 use crate::core::identifier::{Identifier, IdentifierChain, IdentifierChainIterator};
+use crate::core::types::big_object::JBigObjectBuilder;
 use crate::core::types::intermediate_type::{IntermediateType, TypeSpecifier, TypeTail};
 use crate::core::types::primitives::Primitive;
 use crate::core::types::{JodinType, Type};
 use crate::utility::Visitor;
 use std::collections::HashMap;
 use std::ops::{Deref, Index};
-use crate::core::types::big_object::JBigObjectBuilder;
 
 /// Stores a lot of information about types and related identifier
 #[derive(Debug, Default)]
@@ -90,8 +90,6 @@ impl TypeEnvironment<'_> {
                 id.clone(),
             )))
     }
-
-
 
     pub fn is_child_type(&self, child: &Identifier, parent: &Identifier) -> bool {
         todo!()

--- a/jodinc/src/parsing/jodin_grammar.lalrpop
+++ b/jodinc/src/parsing/jodin_grammar.lalrpop
@@ -64,6 +64,7 @@ pub CanonicalType: IntermediateType = {
     },
     "[" <ty:CanonicalType> ":" <len:Expression> "]" => {
         ty.with_array(len.expect("This should be a constant expression"))
+        .expect("Given length was invalid constant expression")
     },
 }
 

--- a/jodinc/src/passes/optimization/constant_expressions.rs
+++ b/jodinc/src/passes/optimization/constant_expressions.rs
@@ -1,0 +1,26 @@
+//! Replace all constant expressions
+
+use std::collections::HashMap;
+use crate::ast::JodinNode;
+use crate::core::error::JodinResult;
+use crate::core::identifier::Identifier;
+use crate::core::literal::Literal;
+
+fn find_constant_expressions(node_tree: &JodinNode) -> JodinResult<HashMap<Identifier, Literal>> {
+    let mut output = HashMap::new();
+
+    Ok(output)
+}
+
+pub fn replace_constant_expressions(mut input: JodinNode) -> JodinResult<JodinNode> {
+    let map = find_constant_expressions(&input)?;
+    _replace_constant_expressions(&mut input, &map)?;
+    Ok(input)
+}
+
+fn _replace_constant_expressions(input: &mut JodinNode, ids: &HashMap<Identifier, Literal>) -> JodinResult<()> {
+
+
+
+    Ok(())
+}

--- a/jodinc/src/passes/optimization/mod.rs
+++ b/jodinc/src/passes/optimization/mod.rs
@@ -3,6 +3,8 @@
 use crate::ast::JodinNode;
 use crate::core::error::JodinResult;
 
+mod constant_expressions;
+
 /// Runs optimizations on a tree
 pub fn optimize(node: JodinNode) -> JodinResult<JodinNode> {
     Ok(node)

--- a/jodinc/src/utility.rs
+++ b/jodinc/src/utility.rs
@@ -89,12 +89,12 @@ pub trait Visitor<Visited, Output> {
 }
 
 pub trait Flatten<T, E> {
-    fn flatten(self) -> Result<T, E>;
+    fn flatten(this: Self) -> Result<T, E>;
 }
 
 impl<T, E> Flatten<T, E> for Result<Result<T, E>, E> {
-    fn flatten(self) -> Result<T, E> {
-        match self {
+    fn flatten(this: Self) -> Result<T, E> {
+        match this {
             Ok(Ok(t)) => Ok(t),
             Ok(Err(e)) => Err(e),
             Err(e) => Err(e),


### PR DESCRIPTION
Array intermediate types no longer use jodin nodes.

Closes #63 